### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/tgallery/handler/gallery_handler.py
+++ b/tgallery/handler/gallery_handler.py
@@ -42,6 +42,6 @@ class GalleryHandler(BaseHandler):
         if filename.lower().endswith(IMAGE_SUFFIX):
             return Picture(filename).get_metadata()
         else:
-            return '%s' % NO_METADATA_MSG
+            return '{0!s}'.format(NO_METADATA_MSG)
 
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:martinhoefling:tornado-gallery?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:martinhoefling:tornado-gallery?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
